### PR TITLE
一覧表示、詳細表示画面、編集画面を実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
   def index
+    @tasks = Task.all
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,6 +4,7 @@ class TasksController < ApplicationController
   end
 
   def show
+    @task = Task.find(params[:id])
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,12 +12,19 @@ class TasksController < ApplicationController
   end
 
   def edit
+    @task = Task.find(params[:id])
   end
 
   def create
     task = Task.new(task_params)
     task.save!
     redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+  end
+
+  def update
+    task = Task.find(params[:id])
+    task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
   private

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,2 +1,13 @@
-h1 Tasks#edit
-p Find me in app/views/tasks/edit.html.slim
+h1 タスクの編集
+
+.nav.justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -3,11 +3,4 @@ h1 タスクの編集
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -11,5 +11,5 @@ table.table.table-hover
   tbody
     - @tasks.each do |task|
       tr
-        td= task.name
+        td= link_to task.name, task
         td= task.created_at

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -8,8 +8,10 @@ table.table.table-hover
     tr
       th= Task.human_attribute_name(:name)
       th= Task.human_attribute_name(:created_at)
+      th
   tbody
     - @tasks.each do |task|
       tr
         td= link_to task.name, task
         td= task.created_at
+        td= link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,2 +1,15 @@
 h1 タスク一覧
+
 = link_to  "新規登録", new_task_path, class: 'btn btn-primary'
+
+.md-3
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= Task.human_attribute_name(:name)
+      th= Task.human_attribute_name(:created_at)
+  tbody
+    - @tasks.each do |task|
+      tr
+        td= task.name
+        td= task.created_at

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,11 +3,4 @@ h1 タスクの新規登録
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -19,3 +19,5 @@ table.table.table-hover
     tr
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
+
+= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -1,2 +1,21 @@
-h1 Tasks#show
-p Find me in app/views/tasks/show.html.slim
+h1 タスクの詳細表示
+
+.nav.justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+table.table.table-hover
+  tbody
+    tr
+      th= Task.human_attribute_name(:id)
+      td= @task.id
+    tr
+      th= Task.human_attribute_name(:name)
+      td= @task.name
+    tr
+      th= Task.human_attribute_name(:description)
+      td= simple_format(h(@task.description), {}, sanitize: false, wrapper_tag: "div")
+    tr
+      th= Task.human_attribute_name(:created_at)
+      td= @task.created_at
+    tr
+      th= Task.human_attribute_name(:updated_at)
+      td= @task.updated_at


### PR DESCRIPTION
- `index` `show` `edit` `update` アクションを編集
- タスクを一覧表示できるように実装
- タスクの詳細画面を表示できるように実装
- 新規画面と編集画面で、共通のフォーム部分をパーシャルで共通化